### PR TITLE
Update deploy_kippo_MySQL_support.sh

### DIFF
--- a/deploy_kippo_MySQL_support.sh
+++ b/deploy_kippo_MySQL_support.sh
@@ -19,7 +19,7 @@ chmod 755 registration.sh
 . ./registration.sh $server_url $deploy_key "kippo-mysql"
 
 apt-get update
-apt-get -y install python-dev openssl python-openssl python-pyasn1 python-twisted git python-pip supervisor authbind python-mysqldb
+apt-get -y install python-dev openssl python-openssl python-pyasn1 python-twisted git python-pip supervisor authbind python-mysqldb openssh-server
 
 
 # Change real SSH Port to 2222


### PR DESCRIPTION
Added the openssh-server package to line 22. This is needed when deploying the script onto a clean Ubuntu server instance.
